### PR TITLE
Fix Linux issues, which were probably shared with OSX

### DIFF
--- a/wadext.cpp
+++ b/wadext.cpp
@@ -85,7 +85,7 @@ char * getdir(const char * lump)
 bool isPatch(const char * n)
 {
 	if (!pstartfound || PNames.mLump < 0) return false;
-	long * l = (long*)PNames.Address();
+	uint32_t * l = (uint32_t*)PNames.Address();
 	char * c = (char*)(l + 1);
 	char nn[9];
 

--- a/wadext.cpp
+++ b/wadext.cpp
@@ -58,7 +58,7 @@ static char* strupr(char* str)
 {
 	for (char* ch = str; '\0' != *ch; ++ch)
 	{
-		*ch = tolower(*ch);
+		*ch = toupper(*ch);
 	}
 	
 	return str;


### PR DESCRIPTION
Fixed two Linux issues. One regarding the integer model, since Windows uses LLP64 and most POSIX systems use LP64, the size of `long` differs, it's 64 bits on Linux and OSX. The other being `strupr` using `tolower`.
This will probably make it work on OSX too, I don't have a Mac so I haven't tested it.